### PR TITLE
Test: 2025-03-10 코딩 기초 트레이닝 문제 풀이

### DIFF
--- a/권수영/training_24.js
+++ b/권수영/training_24.js
@@ -1,0 +1,17 @@
+/* 코드 처리하기 */
+
+function solution(code) {
+  let mode = 0;
+  let ret = '';
+  
+  for(let idx = 0; idx < code.length; idx++) {
+      if(mode === 0){
+      code[idx] === '1' ? (mode = 1) : (idx % 2 === 0 && (ret += code[idx]))
+      } else {
+          code[idx] ==='1' ? (mode = 0) : (idx % 2 !== 0 && (ret += code[idx]))
+      }
+
+  }
+  
+  return ret.length > 0 ? ret : "EMPTY";
+}

--- a/권수영/training_25.js
+++ b/권수영/training_25.js
@@ -1,0 +1,10 @@
+/*등차수열의 특정한 항만 더하기*/
+
+function solution(a, d, included) {
+  const arr = [a]
+  for(let i = 1 ; i < included.length; i++) {
+      arr[i] = arr[i - 1] + d
+  }
+  
+  return arr.reduce((acc, cur, idx) => included[idx] ? acc + cur : acc , 0)
+}

--- a/권수영/training_26.js
+++ b/권수영/training_26.js
@@ -1,0 +1,11 @@
+/* 주사위 게임 2 */
+
+function solution(a, b, c) {
+  if(a === b && b === c && a === c) {
+      return (a + b + c) * (Math.pow(a, 2) + Math.pow(b, 2) + Math.pow(c, 2)) * (Math.pow(a, 3) + Math.pow(b, 3) + Math.pow(c, 3));
+  } else if(a === b || b === c || a === c) {
+      return (a + b + c) * (Math.pow(a, 2) + Math.pow(b, 2) + Math.pow(c, 2));
+  } else {
+      return a + b + c;
+  }
+}

--- a/권수영/training_27.js
+++ b/권수영/training_27.js
@@ -1,0 +1,5 @@
+/* 원소들의 곱과 합 */
+
+function solution(num_list) {
+  return Math.pow(num_list.reduce((a, b) => a + b), 2) > num_list.reduce((a, b) => a * b) ? 1 : 0;
+}

--- a/권수영/training_28.js
+++ b/권수영/training_28.js
@@ -1,0 +1,15 @@
+/* 이어 붙인 수 */
+
+function solution(num_list) {
+  let odd = '';
+  let even = '';
+  
+  for(let i = 0; i < num_list.length; i++) {
+      if(num_list[i] % 2 !== 0) {
+          odd += num_list[i];
+      } else {
+          even += num_list[i];
+      }
+  }
+  return Number(odd) + Number(even);
+}

--- a/권수영/training_29.js
+++ b/권수영/training_29.js
@@ -1,0 +1,6 @@
+/* 마지막 두 원소 */
+
+function solution(num_list) {
+  const [a, b] = [...num_list].reverse();
+  return [...num_list, a > b ? (a - b) : (a * 2)];
+}

--- a/권수영/training_30.js
+++ b/권수영/training_30.js
@@ -1,0 +1,13 @@
+/* 수 조작하기 1 */
+
+function solution(n, control) {
+  for(let i = 0; i < control.length; i++) {
+      switch(control[i]) {
+          case 'w' : n++; break;
+          case 's' : n--; break;
+          case 'd' : n += 10; break;
+          case 'a' : n -= 10; break;
+      }
+  }
+  return n;
+}

--- a/권수영/training_31.js
+++ b/권수영/training_31.js
@@ -1,0 +1,15 @@
+/* 수 조작하기 2 */
+
+function solution(numLog) {
+  let result = ''
+  for(let i = 0; i < numLog.length; i++) {
+      const n = numLog[i+1] - numLog[i];
+      switch(n) {
+          case 1: result += 'w'; break;
+          case -1: result += 's'; break;
+          case 10: result += 'd'; break;
+          case -10: result += 'a'; break;
+      }
+  }
+  return result;
+}

--- a/권수영/training_32.js
+++ b/권수영/training_32.js
@@ -1,0 +1,12 @@
+/* 수열과 구간 쿼리 3 */
+
+function solution(arr, queries) {
+  queries.map((query) => {
+    let i = query[0];
+    let j = query[1];
+    let temp = arr[i];
+    arr[i] = arr[j];
+    arr[j] = temp;
+  });
+  return arr;
+}


### PR DESCRIPTION
## 📆 공부 일자

> 20250310

## 📝 공부 내용

> 코딩 기초 트레이닝 문제 풀이를 진행했다.
1. 코드 처리하기
2. 등차수열의 특정한 항만 더하기
3. 주사위 게임 2
4. 원소들의 곱과 합
5. 이어 붙인 수
+) 문자열 앞에 +를 붙여주면 암묵적으로 타입 변환이 일어난다. 이때 숫자형으로 바뀌게 된다.
return +odd + +even 으로 변환 가능.
6. 마지막 두 원소
reverse 메서드를 사용해 배열 거꾸로 뒤집고 배열 복사본을 생성 후 계산 결과를 복사본 뒤에 추가하여 반환
7. 수 조작하기 1
8. 수 조작하기 2
객체를 사용한 풀이가 있는데, 객체 사용이 익숙하지 않아서 많이 연습해야겠다..
9. 수열과 구간 쿼리 3
다른 풀이로는 구조분해할당을 사용한 풀이가 있었다.

### 스크린샷 (선택)
<img width="357" alt="수열과 구간쿼리" src="https://github.com/user-attachments/assets/0da603f5-e3ce-4ff7-aa63-bdee11811133" /><br>
다른 풀이를 찾아봤더니 구조분해할당을 사용한 풀이가 있었다..<br>
<img width="383" alt="다른 풀이" src="https://github.com/user-attachments/assets/2f1363d3-8098-4291-b0c6-336039926900" />



## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> 더 좋은 풀이가 있다면 알려주세요!
